### PR TITLE
Clean up thread emails page and implement chat-style email display

### DIFF
--- a/frontend/app/(app)/setup/email-setup-step2.tsx
+++ b/frontend/app/(app)/setup/email-setup-step2.tsx
@@ -5,7 +5,7 @@ import { useSession } from '../../../src/context/SessionContext'
 import { colors } from '../../../src/constants'
 
 export default function EmailSetupStep2() {
-  const [appPassword, setAppPassword] = useState('jfjlwpdfoxmfiiew')
+  const [appPassword, setAppPassword] = useState('')
   const [loading, setLoading] = useState(false)
   const { email } = useLocalSearchParams()
   const { session } = useSession()

--- a/frontend/app/(app)/setup/email-setup.tsx
+++ b/frontend/app/(app)/setup/email-setup.tsx
@@ -4,7 +4,7 @@ import { router } from 'expo-router'
 import { colors } from '../../../src/constants'
 
 export default function EmailSetup() {
-  const [email, setEmail] = useState('imadmokadem19@gmail.com')
+  const [email, setEmail] = useState('')
 
   function handleContinue() {
     if (!email.includes('@gmail.com')) {

--- a/frontend/app/(app)/threads/thread-emails.tsx
+++ b/frontend/app/(app)/threads/thread-emails.tsx
@@ -7,50 +7,9 @@ import { Q } from '@nozbe/watermelondb';
 import { database } from '../../../src/database';
 import { Email } from '../../../src/database/models/Email';
 import { Thread } from '../../../src/database/models/Thread';
-import { markEmailAsRead } from '../../../src/services/EmailReadingService';
+import { Contact } from '../../../src/database/models/Contact';
+import EmailChatItem from '../../../src/components/emails/EmailChatItem';
 
-// Observable email item component
-const EmailItem = withObservables(['email'], ({ email }) => ({
-  email: email.observe(),
-}))(({ email }: { email: Email }) => {
-  const handleEmailTap = async () => {
-    if (!email.isRead) {
-      console.log('📧 Marking email as read:', email.subject);
-      await markEmailAsRead(email);
-    }
-  };
-
-  const sender = email.fromName || email.fromAddress;
-  const formatDateTime = (date: Date) => {
-    return date.toLocaleString([], {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-  };
-
-  return (
-    <TouchableOpacity
-      style={styles.emailItem}
-      onPress={handleEmailTap}
-    >
-      <View style={styles.emailHeader}>
-        <View style={styles.emailSender}>
-          <Text style={[styles.sender, !email.isRead && styles.unread]}>
-            {sender}
-          </Text>
-          {!email.isRead && <View style={styles.unreadDot} />}
-        </View>
-        <Text style={styles.date}>{formatDateTime(email.dateSent)}</Text>
-      </View>
-
-      <Text style={styles.bodyPreview} numberOfLines={2}>
-        {email.subject || 'No Subject'}
-      </Text>
-    </TouchableOpacity>
-  );
-});
 
 // Main component wrapped with observables
 const ThreadEmailsContent = withObservables(['threadId'], ({ threadId }) => ({
@@ -82,28 +41,43 @@ const ThreadEmailsContent = withObservables(['threadId'], ({ threadId }) => ({
   }
 
   const renderEmail = ({ item: email }: { item: Email }) => {
-    return <EmailItem email={email} />;
+    return <EmailChatItem email={email} />;
   };
 
   return (
-    <>
-      <View style={styles.threadInfo}>
-        <Text style={styles.threadSubject} numberOfLines={2}>
-          {thread.subject || 'No Subject'}
-        </Text>
-        <Text style={styles.threadMeta}>
-          {emails.length} {emails.length === 1 ? 'email' : 'emails'} •
-          {thread.unreadCount > 0 ? ` ${thread.unreadCount} unread` : ' All read'}
-        </Text>
-      </View>
+    <FlatList
+      data={emails}
+      keyExtractor={(item) => item.id}
+      renderItem={renderEmail}
+      contentContainerStyle={styles.list}
+    />
+  );
+});
 
-      <FlatList
-        data={emails}
-        keyExtractor={(item) => item.id}
-        renderItem={renderEmail}
-        contentContainerStyle={styles.list}
-      />
-    </>
+const ThreadHeader = withObservables(['threadId'], ({ threadId }) => ({
+  thread: database.collections.get<Thread>('threads').findAndObserve(threadId),
+}))(({ thread }: { thread: Thread | null }) => {
+  const [contact, setContact] = React.useState(null);
+
+  React.useEffect(() => {
+    if (thread?.contactId) {
+      database.collections.get('contacts').find(thread.contactId).then(setContact);
+    }
+  }, [thread?.contactId]);
+
+  const displayName = contact ? (contact.name || contact.email) : 'Thread';
+
+  return (
+    <View style={styles.header}>
+      <TouchableOpacity
+        style={styles.backButton}
+        onPress={() => router.back()}
+      >
+        <Text style={styles.backButtonText}>← Back</Text>
+      </TouchableOpacity>
+      <Text style={styles.title}>{displayName}</Text>
+      <View style={styles.placeholder} />
+    </View>
   );
 });
 
@@ -116,16 +90,7 @@ export default function ThreadEmailsScreen() {
   return (
     <View style={styles.container}>
       {/* Header with back button */}
-      <View style={styles.header}>
-        <TouchableOpacity
-          style={styles.backButton}
-          onPress={() => router.back()}
-        >
-          <Text style={styles.backButtonText}>← Back</Text>
-        </TouchableOpacity>
-        <Text style={styles.title}>Thread</Text>
-        <View style={styles.placeholder} />
-      </View>
+      <ThreadHeader threadId={threadId} />
 
       {/* Separator */}
       <View style={styles.separator} />
@@ -167,7 +132,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   title: {
-    fontSize: 20,
+    fontSize: 15,
     fontWeight: '700',
     color: colors.primary,
     letterSpacing: -0.3,
@@ -194,11 +159,6 @@ const styles = StyleSheet.create({
     color: colors.primary,
     marginBottom: 4,
   },
-  threadMeta: {
-    fontSize: 14,
-    color: colors.primary,
-    opacity: 0.6,
-  },
   center: {
     flex: 1,
     justifyContent: 'center',
@@ -211,54 +171,6 @@ const styles = StyleSheet.create({
     opacity: 0.7,
   },
   list: {
-    padding: 16,
-  },
-  emailItem: {
-    backgroundColor: colors.white,
-    borderRadius: 8,
-    padding: 16,
-    marginBottom: 12,
-    shadowColor: colors.black,
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.05,
-    shadowRadius: 2,
-    elevation: 2,
-  },
-  emailHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 8,
-  },
-  emailSender: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-  },
-  sender: {
-    fontSize: 15,
-    color: colors.primary,
-    fontWeight: '500',
-  },
-  date: {
-    fontSize: 12,
-    color: colors.primary,
-    opacity: 0.6,
-  },
-  bodyPreview: {
-    fontSize: 14,
-    color: colors.primary,
-    opacity: 0.8,
-    lineHeight: 20,
-  },
-  unread: {
-    fontWeight: 'bold',
-  },
-  unreadDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: colors.notification,
-    marginLeft: 8,
+    paddingVertical: 8,
   },
 });

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -18,6 +18,7 @@
         "react-native-safe-area-context": "^5.6.1",
         "react-native-screens": "^4.16.0",
         "react-native-url-polyfill": "^2.0.0",
+        "react-native-webview": "^13.16.0",
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -1001,6 +1002,8 @@
     "react-native-url-polyfill": ["react-native-url-polyfill@2.0.0", "", { "dependencies": { "whatwg-url-without-unicode": "8.0.0-3" }, "peerDependencies": { "react-native": "*" } }, "sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA=="],
 
     "react-native-vector-icons": ["react-native-vector-icons@10.3.0", "", { "dependencies": { "prop-types": "^15.7.2", "yargs": "^16.1.1" }, "bin": { "fa5-upgrade": "bin/fa5-upgrade.sh", "fa6-upgrade": "bin/fa6-upgrade.sh", "fa-upgrade.sh": "bin/fa-upgrade.sh", "generate-icon": "bin/generate-icon.js" } }, "sha512-IFQ0RE57819hOUdFvgK4FowM5aMXg7C7XKsuGLevqXkkIJatc3QopN0wYrb2IrzUgmdpfP+QVIbI3S6h7M0btw=="],
+
+    "react-native-webview": ["react-native-webview@13.16.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "invariant": "2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA=="],
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 

--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -1473,6 +1473,30 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - react-native-webview (13.16.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - React-NativeModulesApple (0.79.6):
     - glog
     - hermes-engine
@@ -1928,6 +1952,7 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
+  - react-native-webview (from `../node_modules/react-native-webview`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -2067,6 +2092,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
+  react-native-webview:
+    :path: "../node_modules/react-native-webview"
   React-NativeModulesApple:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
   React-oscompat:
@@ -2189,6 +2216,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 70a29536f84ddffca4a91097651d2b8f194f7c67
   React-microtasksnativemodule: ff05e894231c44c21135d1d23a82b87656d98eeb
   react-native-safe-area-context: 895c49ee2613865f90318789be89a8e286fe7b69
+  react-native-webview: 1d8659a52cb8b8504f6c965555d1b27bdd313880
   React-NativeModulesApple: d94850b316446b0c39a82eb278d6efaa1a634055
   React-oscompat: 56b4766e96b06843a3af49a6763ef40992e720aa
   React-perflogger: 8fe9ec5f9ddbab1b8906c1aec159aa946e0ba041

--- a/frontend/ios/frontend.xcodeproj/project.pbxproj
+++ b/frontend/ios/frontend.xcodeproj/project.pbxproj
@@ -448,7 +448,10 @@
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -503,7 +506,10 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "react-native": "0.79.6",
     "react-native-safe-area-context": "^5.6.1",
     "react-native-screens": "^4.16.0",
-    "react-native-url-polyfill": "^2.0.0"
+    "react-native-url-polyfill": "^2.0.0",
+    "react-native-webview": "^13.16.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
- Replace generic "Thread" header with contact name/email display
- Remove email count and read status notes for cleaner MVP design
- Implement WhatsApp-style chat bubbles for email conversations
- Add EmailChatItem component with WebView modal for full email content
- Reduce header title font size for better proportions
- Switch from basic email list to conversational chat interface

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
